### PR TITLE
Prevent pings by the bot (most importantly @everyone)

### DIFF
--- a/src/main/java/me/reimnop/d4f/Discord.java
+++ b/src/main/java/me/reimnop/d4f/Discord.java
@@ -1,6 +1,7 @@
 package me.reimnop.d4f;
 
 import club.minnced.discord.webhook.WebhookClient;
+import club.minnced.discord.webhook.send.AllowedMentions;
 import club.minnced.discord.webhook.send.WebhookMessageBuilder;
 import me.reimnop.d4f.exceptions.ChannelException;
 import me.reimnop.d4f.exceptions.GuildException;
@@ -91,7 +92,8 @@ public class Discord {
         WebhookMessageBuilder wmb = new WebhookMessageBuilder()
                 .setAvatarUrl(Utils.getAvatarUrl(sender.getUuid()))
                 .setUsername(name.getString())
-                .setContent(message.getString());
+                .setContent(message.getString())
+                .setAllowedMentions(AllowedMentions.none());
 
         webhookClient.send(wmb.build());
     }


### PR DESCRIPTION
Previously it was possible to use @everyone and @here even when the bot didn't have permissions for this (I assume that's because it's using a webhook?). This can be really problematic, if someone abuses it, it is hugely annoying to everyone on the server, and I don't think you can really do anything about it as a server admin.