### PR TITLE
Fix Death and Achievement Events

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,16 +2,16 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.19.1
-yarn_mappings=1.19.1+build.1
-loader_version=0.14.8
+minecraft_version=1.19.2
+yarn_mappings=1.19.2+build.18
+loader_version=0.14.9
 # Mod Properties
 mod_version=1.10.0
 maven_group=me.reimnop
 jar_name=discord4fabric
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.58.5+1.19.1
+fabric_version=0.62.0+1.19.2
 placeholder_version=2.0.0-beta.3+1.19
 jda_version=5.0.0-alpha.12
 webhook_version=0.8.0

--- a/src/main/java/me/reimnop/d4f/mixin/PlayerAdvancementTrackerMixin.java
+++ b/src/main/java/me/reimnop/d4f/mixin/PlayerAdvancementTrackerMixin.java
@@ -16,7 +16,7 @@ public class PlayerAdvancementTrackerMixin {
 
     @Inject(method = "grantCriterion",
             at = @At(
-                target = "Lnet/minecraft/server/PlayerManager;broadcast(Lnet/minecraft/text/Text;Lnet/minecraft/util/registry/RegistryKey;)V",
+                target = "Lnet/minecraft/server/PlayerManager;broadcast(Lnet/minecraft/text/Text;Z)V",
                 value = "INVOKE"
             )
     )

--- a/src/main/java/me/reimnop/d4f/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/me/reimnop/d4f/mixin/ServerPlayerEntityMixin.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 public class ServerPlayerEntityMixin {
     @Inject(method = "onDeath",
             at = @At(
-                target = "Lnet/minecraft/server/network/ServerPlayNetworkHandler;sendPacket(Lnet/minecraft/network/Packet;Lio/netty/util/concurrent/GenericFutureListener;)V",
+                target = "Lnet/minecraft/server/network/ServerPlayNetworkHandler;sendPacket(Lnet/minecraft/network/Packet;Lnet/minecraft/network/PacketCallbacks;)V",
                 value = "INVOKE",
                 ordinal = 0),
             locals = LocalCapture.CAPTURE_FAILSOFT


### PR DESCRIPTION
This PR fixes death and achievement messages by doing the following:
- Updates fabric & minecraft
  - Upgrades the minecraft version to 1.19.2
  - Upgrades the yarn mappings to 1.19.2+build.18
  - Upgrades the loader version to 0.14.9
  - Upgrades the fabric version to 0.62.0+1.19.2
- Fixes the mixin inject targets for the following mixins:
  - ServerPlayerEntityMixin
  - PlayerAdvancementTrackerMixin

Additionally, I've set the mod version to 1.10.1.

Fixes #42

Somewhat related to #54