### PR TITLE
added "sendMessagesToMinecraft" option

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.19.2
 yarn_mappings=1.19.2+build.18
 loader_version=0.14.9
 # Mod Properties
-mod_version=1.10.1
+mod_version=1.10.2
 maven_group=me.reimnop
 jar_name=discord4fabric
 # Dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.19.2
 yarn_mappings=1.19.2+build.18
 loader_version=0.14.9
 # Mod Properties
-mod_version=1.10.2
+mod_version=1.10.2d
 maven_group=me.reimnop
 jar_name=discord4fabric
 # Dependencies

--- a/src/main/java/me/reimnop/d4f/Config.java
+++ b/src/main/java/me/reimnop/d4f/Config.java
@@ -35,6 +35,7 @@ public class Config {
     public String advancementChallengeTitle = "%player:name% has completed the challenge [%d4f:title%]";
     public String advancementChallengeDescription = "%d4f:description%";
     public boolean sendMessagesToDiscord = true;
+    public boolean sendMessagesToMinecraft = true;
     public String discordToMinecraftMessage = "[%d4f:nickname% on Discord] %d4f:message%";
     public String discordToMinecraftWithReplyMessage = "[%d4f:nickname% on Discord (replying to %d4f:reply_nickname%)] %d4f:message%";
     public String discordName = "%player:name%";
@@ -78,6 +79,7 @@ public class Config {
         jsonObject.addProperty("advancement_challenge", advancementChallengeTitle);
         jsonObject.addProperty("advancement_challenge_desc", advancementChallengeDescription);
         jsonObject.addProperty("send_messages_to_discord", sendMessagesToDiscord);
+        jsonObject.addProperty("send_messages_to_minecraft", sendMessagesToMinecraft);
         jsonObject.addProperty("discord_to_mc", discordToMinecraftMessage);
         jsonObject.addProperty("discord_to_mc_reply", discordToMinecraftWithReplyMessage);
         jsonObject.addProperty("discord_name", discordName);
@@ -133,6 +135,7 @@ public class Config {
         advancementChallengeTitle = getStringOrDefault(obj, "advancement_challenge", advancementChallengeTitle);
         advancementChallengeDescription = getStringOrDefault(obj, "advancement_challenge_desc", advancementChallengeDescription);
         sendMessagesToDiscord = getBooleanOrDefault(obj, "send_messages_to_discord", sendMessagesToDiscord);
+        sendMessagesToMinecraft = getBooleanOrDefault(obj, "send_messages_to_minecraft", sendMessagesToMinecraft);
         discordToMinecraftMessage = getStringOrDefault(obj, "discord_to_mc", discordToMinecraftMessage);
         discordToMinecraftWithReplyMessage = getStringOrDefault(obj, "discord_to_mc_reply", discordToMinecraftWithReplyMessage);
         discordName = getStringOrDefault(obj, "discord_name", discordName);

--- a/src/main/java/me/reimnop/d4f/commands/ModCommands.java
+++ b/src/main/java/me/reimnop/d4f/commands/ModCommands.java
@@ -18,7 +18,7 @@ public final class ModCommands {
     public static void init() {
         CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> {
             dispatcher.register(
-                    CommandManager.literal("discord4fabric")
+                    CommandManager.literal("discord")
                             .then(CommandManager.literal("link")
                                     .executes(context -> {
                                         ServerPlayerEntity serverPlayer = context.getSource().getPlayer();

--- a/src/main/java/me/reimnop/d4f/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/me/reimnop/d4f/mixin/ServerPlayerEntityMixin.java
@@ -1,7 +1,10 @@
 package me.reimnop.d4f.mixin;
 
+import me.reimnop.d4f.Config;
 import me.reimnop.d4f.events.PlayerDeathCallback;
 import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.network.message.MessageType;
+import net.minecraft.network.message.SentMessage;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
@@ -12,6 +15,12 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 @Mixin(ServerPlayerEntity.class)
 public class ServerPlayerEntityMixin {
+    @Inject(method = "sendChatMessage", at = @At("HEAD"), cancellable = true)
+    private void blockChat(Config config, SentMessage message, boolean filterMaskEnabled, MessageType.Parameters params, CallbackInfo ci) {
+        if (!config.sendMessagesToMinecraft) {
+            ci.cancel();
+        }
+    }
     @Inject(method = "onDeath",
             at = @At(
                 target = "Lnet/minecraft/server/network/ServerPlayNetworkHandler;sendPacket(Lnet/minecraft/network/Packet;Lnet/minecraft/network/PacketCallbacks;)V",

--- a/src/main/java/me/reimnop/d4f/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/me/reimnop/d4f/mixin/ServerPlayerEntityMixin.java
@@ -16,10 +16,8 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 @Mixin(ServerPlayerEntity.class)
 public class ServerPlayerEntityMixin {
     @Inject(method = "sendChatMessage", at = @At("HEAD"), cancellable = true)
-    private void blockChat(Config config, SentMessage message, boolean filterMaskEnabled, MessageType.Parameters params, CallbackInfo ci) {
-        if (!config.sendMessagesToMinecraft) {
-            ci.cancel();
-        }
+    private void blockChat(Config config,SentMessage message, boolean filterMaskEnabled, MessageType.Parameters params, CallbackInfo ci) {
+        if (!config.sendMessagesToMinecraft) ci.cancel();
     }
     @Inject(method = "onDeath",
             at = @At(

--- a/src/main/java/me/reimnop/d4f/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/me/reimnop/d4f/mixin/ServerPlayerEntityMixin.java
@@ -1,6 +1,7 @@
 package me.reimnop.d4f.mixin;
 
 import me.reimnop.d4f.Config;
+import me.reimnop.d4f.Discord4Fabric;
 import me.reimnop.d4f.events.PlayerDeathCallback;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.network.message.MessageType;
@@ -16,7 +17,8 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 @Mixin(ServerPlayerEntity.class)
 public class ServerPlayerEntityMixin {
     @Inject(method = "sendChatMessage", at = @At("HEAD"), cancellable = true)
-    private void blockChat(Config config,SentMessage message, boolean filterMaskEnabled, MessageType.Parameters params, CallbackInfo ci) {
+    private void blockChat(SentMessage message, boolean filterMaskEnabled, MessageType.Parameters params, CallbackInfo ci) {
+        Config config = Discord4Fabric.CONFIG;
         if (!config.sendMessagesToMinecraft) ci.cancel();
     }
     @Inject(method = "onDeath",


### PR DESCRIPTION
gives you a option in config (config/discord4fabric.json)
`"send_messages_to_minecraft": true,`

which can be used to turn off the messages sent to Minecraft instance/backend this is installed on, 
this is useful when in a bungee/velocity network where the proxy chat is used instead, but still allows you do use this mod for discord, along with all the custom_events.