### PR TITLE
handle too long console messages

### DIFF
--- a/src/main/java/me/reimnop/d4f/console/ConsoleChannelHandler.java
+++ b/src/main/java/me/reimnop/d4f/console/ConsoleChannelHandler.java
@@ -58,10 +58,22 @@ public final class ConsoleChannelHandler {
             }
 
             String msg = event.getMessage().getFormattedMessage();
-            if (buffer.getLength() + msg.length() > 2000) {
-                buffer.flush();
-            }
-            buffer.writeLine(msg);
+            addMessage(msg);
         });
+    }
+
+    private static void addMessage(String msg) {
+        if (threadShouldStop) return;
+        if (msg.length() > 2000) {
+            String[] lines = msg.split("\n");
+            for (String line : lines) {
+                addMessage(line);
+            }
+            return;
+        }
+        if (buffer.getLength() + msg.length() > 2000) {
+            buffer.flush();
+        }
+        buffer.writeLine(msg);
     }
 }


### PR DESCRIPTION
Added a method to check if the length of a console message is longer than 2000 characters, if so, split it by \n and run those lines through the method separately.
This fixes #75 