### PR TITLE
Filter DrexHD Vanished players from the `!playerlist` discord command

### DIFF
--- a/src/main/java/me/reimnop/d4f/listeners/DiscordCommandProcessor.java
+++ b/src/main/java/me/reimnop/d4f/listeners/DiscordCommandProcessor.java
@@ -1,5 +1,6 @@
 package me.reimnop.d4f.listeners;
 
+import me.drex.vanish.api.VanishAPI;
 import me.reimnop.d4f.Config;
 import me.reimnop.d4f.Discord;
 import me.reimnop.d4f.Discord4Fabric;
@@ -7,8 +8,11 @@ import me.reimnop.d4f.events.DiscordMessageReceivedCallback;
 import me.reimnop.d4f.utils.Utils;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.PlayerManager;
+import net.minecraft.server.network.ServerPlayerEntity;
 
 
+import java.util.Arrays;
 import java.util.Map;
 
 public final class DiscordCommandProcessor {
@@ -25,6 +29,8 @@ public final class DiscordCommandProcessor {
             "playerlist", server -> {
                 int maxPlayers = server.getMaxPlayerCount();
                 String[] playerNames = server.getPlayerNames();
+                playerNames = filterDrexHDVanishedPlayers(server, playerNames);
+
 
                 StringBuilder stringBuilder = new StringBuilder();
                 if(playerListDisplayAmount == 0){
@@ -81,5 +87,36 @@ public final class DiscordCommandProcessor {
 
         playerListDisplayAmount = config.playerListDisplayAmount;
 
+    }
+
+    /**
+     * Filters out players who have vanished using <a href="https://github.com/DrexHD/Vanish">DrexHD's Vanish mod</a>
+     * from the player list command.
+     *
+     * @param server The Minecraft server the players are on
+     * @param unfilteredNames An unfiltered array of player names {@linkplain PlayerManager#getPlayerNames() obtained
+     * from the player manager}.
+     * @return Returns a list of player names on the server, without the names of vanished players. If DrexHD's Vanish
+     * mod is not loaded, then returns the original unfiltered names.
+     */
+    private static String[] filterDrexHDVanishedPlayers(MinecraftServer server, String[] unfilteredNames) {
+
+        if (!FabricLoader.getInstance().isModLoaded("melius-vanish")) {
+            return unfilteredNames;
+        }
+
+        return Arrays.stream(unfilteredNames)
+                .filter(
+                        name -> {
+                            PlayerManager manager = server.getPlayerManager();
+                            ServerPlayerEntity player = manager.getPlayer(name);
+                            // player should never be null as the names are assumed to all be valid
+                            return player != null && !VanishAPI.isVanished(
+                                    server,
+                                    player.getUuid()
+                            );
+                        }
+                )
+                .toArray(String[]::new);
     }
 }


### PR DESCRIPTION
I saw that [DrexHD's Vanish mod](https://github.com/DrexHD/Vanish) was recently integrated into the mod in #104, and found an issue where players could still see the vanished players online if they used the `!playerlist` command on Discord. This PR fixes that, by filtering out all player names for vanished players. It does not require that Vanish be installed, and nothing will be different if it isn't. 