### PR TITLE
Improves vanish support

### DIFF
--- a/src/main/java/me/reimnop/d4f/listeners/CustomEventsHandler.java
+++ b/src/main/java/me/reimnop/d4f/listeners/CustomEventsHandler.java
@@ -70,6 +70,10 @@ public final class CustomEventsHandler {
         });
 
         PlayerDeathCallback.EVENT.register((player, source, deathMessage) -> {
+            // Vanish compatibility
+            if (Compatibility.isPlayerVanished(player)) {
+                return;
+            }
             PlaceholderContext placeholderContext = PlaceholderContext.of(player);
 
             Map<Identifier, PlaceholderHandler> placeholders = Map.of(
@@ -146,6 +150,10 @@ public final class CustomEventsHandler {
         });
 
         PlayerAdvancementCallback.EVENT.register((player, advancement) -> {
+            // Vanish compatibility
+            if (Compatibility.isPlayerVanished(player)) {
+                return;
+            }
             PlaceholderContext placeholderContext = PlaceholderContext.of(player);
             Optional<AdvancementDisplay> advancementDisplay = advancement.display();
             String advancementTitle;

--- a/src/main/java/me/reimnop/d4f/listeners/DiscordCommandProcessor.java
+++ b/src/main/java/me/reimnop/d4f/listeners/DiscordCommandProcessor.java
@@ -5,6 +5,7 @@ import me.reimnop.d4f.Config;
 import me.reimnop.d4f.Discord;
 import me.reimnop.d4f.Discord4Fabric;
 import me.reimnop.d4f.events.DiscordMessageReceivedCallback;
+import me.reimnop.d4f.utils.Compatibility;
 import me.reimnop.d4f.utils.Utils;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.server.MinecraftServer;
@@ -101,7 +102,7 @@ public final class DiscordCommandProcessor {
      */
     private static String[] filterDrexHDVanishedPlayers(MinecraftServer server, String[] unfilteredNames) {
 
-        if (!FabricLoader.getInstance().isModLoaded("melius-vanish")) {
+        if (!Compatibility.isVanishModLoaded()) {
             return unfilteredNames;
         }
 
@@ -111,10 +112,7 @@ public final class DiscordCommandProcessor {
                             PlayerManager manager = server.getPlayerManager();
                             ServerPlayerEntity player = manager.getPlayer(name);
                             // player should never be null as the names are assumed to all be valid
-                            return player != null && !VanishAPI.isVanished(
-                                    server,
-                                    player.getUuid()
-                            );
+                            return player != null && Compatibility.isPlayerVanished(player);
                         }
                 )
                 .toArray(String[]::new);

--- a/src/main/java/me/reimnop/d4f/listeners/EventRedirect.java
+++ b/src/main/java/me/reimnop/d4f/listeners/EventRedirect.java
@@ -5,24 +5,17 @@ import me.reimnop.d4f.events.OnPlayerVanishCallback;
 import me.reimnop.d4f.events.PlayerConnectedCallback;
 import me.reimnop.d4f.events.PlayerDisconnectedCallback;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
-import net.fabricmc.loader.api.FabricLoader;
-
-import static me.drex.vanish.api.VanishAPI.isVanished;
 
 public final class EventRedirect {
     private EventRedirect() {}
 
     public static void init() {
         ServerPlayConnectionEvents.JOIN.register((handler, sender, server) -> {
-            if (!(FabricLoader.getInstance().isModLoaded("melius-vanish") && isVanished(handler.player))) {
-                PlayerConnectedCallback.EVENT.invoker().onConnected(handler.player, server, false);
-            }
+            PlayerConnectedCallback.EVENT.invoker().onConnected(handler.player, server, false);
         });
 
         ServerPlayConnectionEvents.DISCONNECT.register((handler, server) -> {
-            if (!(FabricLoader.getInstance().isModLoaded("melius-vanish") && isVanished(handler.player))) {
-                PlayerDisconnectedCallback.EVENT.invoker().onDisconnected(handler.player, server, false);
-            }
+            PlayerDisconnectedCallback.EVENT.invoker().onDisconnected(handler.player, server, false);
         });
 
         OnPlayerVanishCallback.EVENT.register(player -> {

--- a/src/main/java/me/reimnop/d4f/listeners/MinecraftEventListeners.java
+++ b/src/main/java/me/reimnop/d4f/listeners/MinecraftEventListeners.java
@@ -49,6 +49,10 @@ public final class MinecraftEventListeners {
             if (!config.announceAdvancement) {
                 return;
             }
+            // Vanish compatibility
+            if(Compatibility.isPlayerVanished(playerEntity)) {
+                return;
+            }
 
             Optional<AdvancementDisplay> advancementDisplay = advancement.display();
             if (advancementDisplay.isEmpty()) {
@@ -508,6 +512,11 @@ public final class MinecraftEventListeners {
 
         PlayerDeathCallback.EVENT.register(((playerEntity, source, deathMessage) -> {
             if (!config.announcePlayerDeath) {
+                return;
+            }
+
+            // Vanish compatibility
+            if (Compatibility.isPlayerVanished(playerEntity)) {
                 return;
             }
 

--- a/src/main/java/me/reimnop/d4f/utils/Compatibility.java
+++ b/src/main/java/me/reimnop/d4f/utils/Compatibility.java
@@ -1,14 +1,20 @@
 package me.reimnop.d4f.utils;
 
 import eu.vanish.Vanish;
+import me.drex.vanish.api.VanishAPI;
 import net.minecraft.server.network.ServerPlayerEntity;
 
 public final class Compatibility {
     private Compatibility() {}
 
     public static final String VANISH_ID = "vanish";
+    public static final String DREXHD_VANISH_ID = "melius-vanish";
 
     public static boolean isPlayerVanished(ServerPlayerEntity player) {
-        return Utils.isModLoaded(VANISH_ID) && Vanish.INSTANCE.vanishedPlayers.isVanished(player);
+        return (Utils.isModLoaded(VANISH_ID) && Vanish.INSTANCE.vanishedPlayers.isVanished(player)) ||
+                (Utils.isModLoaded(DREXHD_VANISH_ID) && VanishAPI.isVanished(player));
+    }
+    public static boolean isVanishModLoaded() {
+        return Utils.isModLoaded(VANISH_ID) || Utils.isModLoaded(DREXHD_VANISH_ID);
     }
 }


### PR DESCRIPTION
Uses `Compatibility.isPlayerVanished` to check for vanish status. Also, avoid sending discord messages on advancements and deaths when the player is vanished