### PR TITLE
Fix !playerlist only showing vanished players

### DIFF
--- a/src/main/java/me/reimnop/d4f/listeners/DiscordCommandProcessor.java
+++ b/src/main/java/me/reimnop/d4f/listeners/DiscordCommandProcessor.java
@@ -112,7 +112,7 @@ public final class DiscordCommandProcessor {
                             PlayerManager manager = server.getPlayerManager();
                             ServerPlayerEntity player = manager.getPlayer(name);
                             // player should never be null as the names are assumed to all be valid
-                            return player != null && Compatibility.isPlayerVanished(player);
+                            return player != null && !Compatibility.isPlayerVanished(player);
                         }
                 )
                 .toArray(String[]::new);


### PR DESCRIPTION
Found a bug where *only* vanished players would show up in the `!playerlist` command on Discord. Looks like #109 might've accidentally inverted the check lol. 